### PR TITLE
Allow `skipFocus` property to be passed to skip the focus in the `draw` method

### DIFF
--- a/pikaday.js
+++ b/pikaday.js
@@ -987,7 +987,8 @@
                 /**
                  * The focus here is not always desirable because it refocuses on the pikaday input upon tabbing while what
                  * we want is to move to the next field. We can skip the focus since we aren't using keyboard input;
-                 * however, in case we want to enable keyboard input in the future, we should change this.
+                 * however, in case we want to enable keyboard input in the future, we should create a new component
+                 * where we do not pass true to `skipFocus`.
                  */
                 if(opts.field.type !== 'hidden' && !opts.skipFocus) {
                     sto(function() {

--- a/pikaday.js
+++ b/pikaday.js
@@ -265,7 +265,10 @@
         onDraw: null,
 
         // Enable keyboard input
-        keyboardInput: true
+        keyboardInput: true,
+
+        // Skip the focus on draw
+        skipFocus: false
     },
 
 
@@ -981,7 +984,12 @@
             this.el.innerHTML = html;
 
             if (opts.bound) {
-                if(opts.field.type !== 'hidden') {
+                /**
+                 * The focus here is not always desirable because it refocuses on the pikaday input upon tabbing while what
+                 * we want is to move to the next field. We can skip the focus since we aren't using keyboard input;
+                 * however, in case we want to enable keyboard input in the future, we should change this.
+                 */
+                if(opts.field.type !== 'hidden' && !opts.skipFocus) {
                     sto(function() {
                         opts.trigger.focus();
                     }, 1);


### PR DESCRIPTION
When `draw` is called, the focus is triggered on the Pikaday input. This causes the next field to be blurred and the error for the next field to show, which is undesirable. We don't need the focus when we are not using keyboard input, and so we can choose to pass true to `skipFocus`.